### PR TITLE
revert reasoning effort level

### DIFF
--- a/src/lib/helpers/types/agentTypes.js
+++ b/src/lib/helpers/types/agentTypes.js
@@ -17,7 +17,6 @@
  * @property {string?} model
  * @property {number} max_recursion_depth
  * @property {number?} [max_output_tokens]
- * @property {string?} [reasoning_effort_level]
  */
 
 

--- a/src/routes/page/agent/[agentId]/agent-components/agent-llm-config.svelte
+++ b/src/routes/page/agent/[agentId]/agent-components/agent-llm-config.svelte
@@ -19,6 +19,7 @@
     }
 
     const recursiveDepthLowerLimit = 1;
+    
     /** @type {import('$commonTypes').LabelValuePair[]} */
 	const reasonLevelOptions = [
         { value: '', label: '' },
@@ -99,12 +100,6 @@
     }
 
     /** @param {any} e */
-    function changeReasoningEffortLevel(e) {
-        config.reasoning_effort_level = e.target.value || null;
-        handleAgentChange();
-    }
-
-    /** @param {any} e */
     function validateIntegerInput(e) {
         const reg = new RegExp(INTEGER_REGEX, 'g');
         if (e.key !== 'Backspace' && !reg.test(e.key)) {
@@ -177,21 +172,6 @@
                     on:keydown={e => validateIntegerInput(e)}
                     on:change={e => changeMaxOutputToken(e)}
                 />
-            </div>
-        </div>
-
-        <div class="mb-3 row">
-            <label for="example-text-input" class="col-md-3 col-form-label">
-                Reasoning level
-            </label>
-            <div class="col-md-9">
-                <Input type="select" value={config.reasoning_effort_level} on:change={e => changeReasoningEffortLevel(e)}>
-                    {#each reasonLevelOptions as option}
-                        <option value={option.value} selected={option.value == config.reasoning_effort_level}>
-                            {option.label}
-                        </option>
-                    {/each}
-                </Input>
             </div>
         </div>
     </CardBody>


### PR DESCRIPTION
### **PR Type**
Other


___

### **Description**
- Remove reasoning effort level configuration from agent LLM settings

- Delete associated UI components and event handlers

- Clean up type definitions and imports


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Agent LLM Config"] --> B["Remove Reasoning Level UI"]
  A --> C["Remove Event Handler"]
  A --> D["Update Type Definitions"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>agent-llm-config.svelte</strong><dd><code>Remove reasoning level UI and handlers</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/routes/page/agent/[agentId]/agent-components/agent-llm-config.svelte

<ul><li>Remove reasoning effort level dropdown UI component<br> <li> Delete <code>changeReasoningEffortLevel</code> event handler function<br> <li> Clean up unused <code>reasonLevelOptions</code> variable references</ul>


</details>


  </td>
  <td><a href="https://github.com/SciSharp/BotSharp-UI/pull/370/files#diff-0644b235310a1c306c16d72641204ad81257690f5c260dd579a2f10e3fbed6ca">+1/-21</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>agentTypes.js</strong><dd><code>Update AgentLlmConfig type definition</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/lib/helpers/types/agentTypes.js

<ul><li>Remove <code>reasoning_effort_level</code> property from <code>AgentLlmConfig</code> type <br>definition</ul>


</details>


  </td>
  <td><a href="https://github.com/SciSharp/BotSharp-UI/pull/370/files#diff-85d3187bd4de05e1bdac978890ab8f4389e04ac1704faa50b3f072fe03ec687c">+0/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

