### PR TITLE
Features/refine chat window

### DIFF
--- a/src/routes/chat/[agentId]/[conversationId]/rich-content/rc-message.svelte
+++ b/src/routes/chat/[agentId]/[conversationId]/rich-content/rc-message.svelte
@@ -27,8 +27,7 @@
             {#if message?.rich_content?.message?.rich_type === RichType.ProgramCode
                 && message?.rich_content?.message?.language === 'javascript'}
                 <RcJsInterpreter message={message} scrollable />
-            {:else if message?.rich_content?.message?.rich_type === RichType.ProgramCode
-                && message?.rich_content?.message?.language === 'python'}
+            {:else if message?.rich_content?.message?.rich_type === RichType.ProgramCode}
                 <Markdown containerClasses={markdownClasses} text={message?.text} rawText />
             {:else}
                 <Markdown containerClasses={markdownClasses} text={text} rawText />

--- a/src/routes/page/conversation/[conversationId]/conv-dialog-element.svelte
+++ b/src/routes/page/conversation/[conversationId]/conv-dialog-element.svelte
@@ -23,8 +23,7 @@
   {#if dialog?.rich_content?.message?.rich_type === RichType.ProgramCode
       && dialog?.rich_content?.message?.language === 'javascript'}
     <RcJsInterpreter message={dialog} scrollable containerStyles={'color: var(--bs-primary);'} />
-  {:else if dialog?.rich_content?.message?.rich_type === RichType.ProgramCode
-      && dialog?.rich_content?.message?.language === 'python'}
+  {:else if dialog?.rich_content?.message?.rich_type === RichType.ProgramCode}
     <Markdown
       containerClasses={'dialog-item-text'}
       text={dialog?.text}

--- a/src/routes/page/conversation/[conversationId]/conv-dialog-element.svelte
+++ b/src/routes/page/conversation/[conversationId]/conv-dialog-element.svelte
@@ -23,6 +23,13 @@
   {#if dialog?.rich_content?.message?.rich_type === RichType.ProgramCode
       && dialog?.rich_content?.message?.language === 'javascript'}
     <RcJsInterpreter message={dialog} scrollable containerStyles={'color: var(--bs-primary);'} />
+  {:else if dialog?.rich_content?.message?.rich_type === RichType.ProgramCode
+      && dialog?.rich_content?.message?.language === 'python'}
+    <Markdown
+      containerClasses={'dialog-item-text'}
+      text={dialog?.text}
+      rawText
+    />
   {:else}
     <Markdown
       containerClasses={'dialog-item-text'}


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Unified handling of program code rendering across chat and conversation views

- Removed Python-specific condition, now all non-JavaScript code uses Markdown rendering

- Added consistent code block display for conversation dialog elements


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Rich Content Message"] --> B{"JavaScript Code?"}
  B -- "Yes" --> C["RcJsInterpreter"]
  B -- "No" --> D{"Program Code?"}
  D -- "Yes" --> E["Markdown Renderer"]
  D -- "No" --> E
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>rc-message.svelte</strong><dd><code>Simplify program code rendering conditions</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/routes/chat/[agentId]/[conversationId]/rich-content/rc-message.svelte

<ul><li>Removed Python-specific language check condition<br> <li> Simplified conditional logic to handle all non-JavaScript program code <br>uniformly<br> <li> All program code except JavaScript now renders through Markdown <br>component</ul>


</details>


  </td>
  <td><a href="https://github.com/SciSharp/BotSharp-UI/pull/389/files#diff-5d6d199e308e6a1350aa5489c6f81f3baeb34f15140f7dc1e2c169882f7dcf6a">+1/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>conv-dialog-element.svelte</strong><dd><code>Add program code rendering support to dialog</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/routes/page/conversation/[conversationId]/conv-dialog-element.svelte

<ul><li>Added new condition for non-JavaScript program code rendering<br> <li> Program code now displays using Markdown component with <code>rawText</code> flag<br> <li> Maintains JavaScript interpreter for JavaScript code blocks</ul>


</details>


  </td>
  <td><a href="https://github.com/SciSharp/BotSharp-UI/pull/389/files#diff-b1373844e3498e60e9b2c89948dc8eef43bd5ef548ccc0cc82b2c4fb73129dc1">+6/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

