### PR TITLE
display seconds in instruction log

### DIFF
--- a/src/routes/page/instruction/log/log-item.svelte
+++ b/src/routes/page/instruction/log/log-item.svelte
@@ -23,7 +23,7 @@
     <td class="instruction-log-col ellipsis">{item.model}</td>
     <td class="instruction-log-col ellipsis">{item.template_name || 'N/A'}</td>
     <td class="instruction-log-col ellipsis">{item.user_name || 'N/A'}</td>
-    <td class="instruction-log-col ellipsis">{utcToLocal(item.created_time)}</td>
+    <td class="instruction-log-col ellipsis">{utcToLocal(item.created_time, 'MMM D YYYY, hh:mm:ss A')}</td>
     <td>
         <ul class="list-unstyled hstack gap-1 mb-0" style="justify-content: center;">
             <li data-bs-toggle="tooltip" data-bs-placement="top" title="Detail">


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Display seconds in instruction log timestamps

- Update time format to include hours, minutes, and seconds

- Change format from default to 'MMM D YYYY, hh:mm:ss A'


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["utcToLocal function"] -- "add format parameter" --> B["'MMM D YYYY, hh:mm:ss A'"]
  B -- "displays" --> C["Timestamp with seconds"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>log-item.svelte</strong><dd><code>Add seconds to timestamp display format</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/routes/page/instruction/log/log-item.svelte

<ul><li>Updated <code>utcToLocal()</code> function call to include explicit time format <br>parameter<br> <li> Changed format from default to 'MMM D YYYY, hh:mm:ss A' to display <br>seconds<br> <li> Affects the created_time column in the instruction log table</ul>


</details>


  </td>
  <td><a href="https://github.com/SciSharp/BotSharp-UI/pull/392/files#diff-45512b18459661cfe77349aeb4ad31f41565f7bb2b05dc7837a6ff01e4b51209">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

