### PR TITLE
adjust reasoning level options based on models

### DIFF
--- a/src/lib/helpers/enums.js
+++ b/src/lib/helpers/enums.js
@@ -239,10 +239,12 @@ const llmModelCapability = {
 export const LlmModelCapability = Object.freeze(llmModelCapability);
 
 const reasoningEffortLevel = {
+    None: "none",
     Minimal: "minimal",
     Low: "low",
     Medium: "medium",
-    High: "high"
+    High: "high",
+    XHigh: "xhigh"
 };
 export const ReasoningEffortLevel = Object.freeze(reasoningEffortLevel);
 


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Dynamically adjust reasoning level options based on selected model capabilities

- Add support for additional reasoning effort levels (none, xhigh)

- Update reasoning level label and automatically reset invalid selections

- Trigger model change handler when provider or model selection changes


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Model Selection"] -->|onModelChanged| B["Get Model Reasoning Config"]
  B -->|Extract EffortLevel Options| C["Update reasoningLevelOptions"]
  C -->|Validate Current Selection| D["Reset if Invalid"]
  D -->|Update UI| E["Reasoning Level Dropdown"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>chat-config.svelte</strong><dd><code>Dynamic reasoning level options based on model</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/routes/page/agent/[agentId]/agent-components/llm-configs/chat-config.svelte

<ul><li>Renamed <code>reasonLevelOptions</code> to <code>defaultReasonLevelOptions</code> and made it a <br>reactive variable <code>reasoningLevelOptions</code><br> <li> Added <code>onModelChanged()</code> function to update reasoning level options when <br>model changes<br> <li> Added <code>getReasoningLevelOptions()</code> function to extract model-specific <br>reasoning effort levels from model configuration<br> <li> Call <code>onModelChanged()</code> in provider and model change handlers to <br>dynamically update available options<br> <li> Changed label from "Reasoning effort" to "Reasoning level"<br> <li> Automatically reset reasoning effort level if current selection is <br>invalid for new model</ul>


</details>


  </td>
  <td><a href="https://github.com/SciSharp/BotSharp-UI/pull/409/files#diff-511e38292216ee8a0e68f10989a3bc1c44dfd2bf76b20e50b3669ed16c73aa55">+40/-4</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>enums.js</strong><dd><code>Add none and xhigh reasoning effort levels</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/lib/helpers/enums.js

<ul><li>Added <code>None: "none"</code> option to reasoning effort levels<br> <li> Added <code>XHigh: "xhigh"</code> option to reasoning effort levels<br> <li> Expanded supported reasoning effort level range from 4 to 5 options</ul>


</details>


  </td>
  <td><a href="https://github.com/SciSharp/BotSharp-UI/pull/409/files#diff-cd70dcbcf013861ea78c8d511262c95da0cb698ab143291baeb9d891e7ce0c36">+3/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

