### PR TITLE
fix reasoning level

### DIFF
--- a/src/routes/page/agent/[agentId]/agent-components/llm-configs/chat-config.svelte
+++ b/src/routes/page/agent/[agentId]/agent-components/llm-configs/chat-config.svelte
@@ -87,6 +87,7 @@
         config.is_inherit = false;
         models = getLlmModels(provider);
         config.model = models[0]?.name;
+        config.reasoning_effort_level = null;
         onModelChanged(config);
         handleAgentChange();
     }
@@ -96,6 +97,7 @@
         config.is_inherit = false;
         config.model = e.target.value || null;
         onModelChanged(config);
+        config.reasoning_effort_level = null;
         handleAgentChange();
     }
 
@@ -135,11 +137,6 @@
     /** @param {import('$agentTypes').AgentLlmConfig | null} config */
     function onModelChanged(config) {
         reasoningLevelOptions = getReasoningLevelOptions(config?.model);
-
-        if (config && !reasoningLevelOptions.some(x => x.value === config.reasoning_effort_level)) {
-            const defaultOption = reasoningLevelOptions.find(x => !!x.value)?.value || null;
-            config.reasoning_effort_level = defaultOption;
-        }
     }
 
     /** @param {string | null | undefined} model */


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Reset reasoning effort level when provider or model changes

- Remove automatic default reasoning level assignment logic

- Ensure reasoning level is explicitly set by user, not auto-populated


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Provider/Model Change"] --> B["Reset reasoning_effort_level to null"]
  B --> C["Remove Auto-Default Logic"]
  C --> D["User Explicitly Sets Level"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>chat-config.svelte</strong><dd><code>Reset reasoning level on provider/model changes</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/routes/page/agent/[agentId]/agent-components/llm-configs/chat-config.svelte

<ul><li>Added <code>config.reasoning_effort_level = null</code> reset in <code>changeProvider()</code> <br>function when model selection changes<br> <li> Added <code>config.reasoning_effort_level = null</code> reset in <code>changeModel()</code> <br>function when model is changed<br> <li> Removed automatic default reasoning level assignment logic from <br><code>onModelChanged()</code> function that was overriding user settings<br> <li> Simplified <code>onModelChanged()</code> to only update available reasoning level <br>options without modifying config values</ul>


</details>


  </td>
  <td><a href="https://github.com/SciSharp/BotSharp-UI/pull/417/files#diff-511e38292216ee8a0e68f10989a3bc1c44dfd2bf76b20e50b3669ed16c73aa55">+2/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

