### PR TITLE
use window self top to detect iframe

### DIFF
--- a/src/routes/chat/[agentId]/[conversationId]/chat-box.svelte
+++ b/src/routes/chat/[agentId]/[conversationId]/chat-box.svelte
@@ -375,7 +375,7 @@
 	}
 
 	function initChatView() {
-		isFrame = window.location != window.parent.location;
+		isFrame = window.self != window.top;
 		mode = $page.url.searchParams.get('mode') || '';
 		// initial condition
 		isPersistLogClosed = false;


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Replace iframe detection method with more reliable window comparison

- Use `window.self != window.top` instead of location-based detection

- Improves iframe detection accuracy in chat view initialization


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["initChatView function"] -- "iframe detection" --> B["Old: window.location != window.parent.location"]
  A -- "iframe detection" --> C["New: window.self != window.top"]
  C -- "sets" --> D["isFrame variable"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>chat-box.svelte</strong><dd><code>Update iframe detection method in chat view</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/routes/chat/[agentId]/[conversationId]/chat-box.svelte

<ul><li>Changed iframe detection logic in <code>initChatView()</code> function<br> <li> Replaced location-based comparison with window object comparison<br> <li> Uses <code>window.self != window.top</code> for more reliable iframe detection</ul>


</details>


  </td>
  <td><a href="https://github.com/SciSharp/BotSharp-UI/pull/419/files#diff-94168668e6f2d07448520397f0d09e112651da024566413b9227c6aad8ba367d">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

