### PR TITLE
feat: Create reusable TimeRangePicker component with tabbed interface

### DIFF
--- a/src/lib/common/shared/TimeRangePicker.svelte
+++ b/src/lib/common/shared/TimeRangePicker.svelte
@@ -1,0 +1,229 @@
+<script>
+	import { createEventDispatcher } from 'svelte';
+	import { Button, Input } from '@sveltestrap/sveltestrap';
+	import { TIME_RANGE_OPTIONS, CUSTOM_DATE_RANGE } from '$lib/helpers/constants';
+	import { clickoutsideDirective } from '$lib/helpers/directives';
+
+	/** @type {string} */
+	export let timeRange = '';
+
+	/** @type {string} */
+	export let startDate = '';
+
+	/** @type {string} */
+	export let endDate = '';
+
+	/** @type {string} */
+	let timeRangeDisplayText = '';
+
+	/** @type {boolean} */
+	let showDatePicker = false;
+
+	/** @type {HTMLDivElement | null} */
+	let datePickerRef = null;
+
+	/** @type {string} */
+	let datePickerTab = 'relative';
+
+	// Preset time range options
+	const presetTimeRangeOptions = TIME_RANGE_OPTIONS.map(x => ({
+		label: x.label,
+		value: x.value
+	}));
+
+	// Get today's date in YYYY-MM-DD format
+	const getTodayStr = () => {
+		const d = new Date();
+		return d.getFullYear() + '-' + String(d.getMonth() + 1).padStart(2, '0') + '-' + String(d.getDate()).padStart(2, '0');
+	};
+
+	// Get yesterday's date in YYYY-MM-DD format
+	const getYesterdayStr = () => {
+		const d = new Date();
+		d.setDate(d.getDate() - 1);
+		return d.getFullYear() + '-' + String(d.getMonth() + 1).padStart(2, '0') + '-' + String(d.getDate()).padStart(2, '0');
+	};
+
+	// Format date for display (YYYY-MM-DD -> MM/DD/YYYY)
+	const formatDateForDisplay = (/** @type {string} */ dateStr) => {
+		if (!dateStr) return '';
+		const [year, month, day] = dateStr.split('-');
+		return `${month}/${day}/${year}`;
+	};
+
+	// Update time range display text reactively
+	$: {
+		if (timeRange === CUSTOM_DATE_RANGE && startDate && endDate) {
+			const start = formatDateForDisplay(startDate);
+			const end = formatDateForDisplay(endDate);
+			if (start === end) {
+				timeRangeDisplayText = start;
+			} else {
+				timeRangeDisplayText = `${start} - ${end}`;
+			}
+		} else if (timeRange === CUSTOM_DATE_RANGE) {
+			timeRangeDisplayText = 'Custom';
+		} else {
+			const selected = presetTimeRangeOptions.find(x => x.value === timeRange);
+			timeRangeDisplayText = selected ? selected.label : '';
+		}
+	}
+
+	const dispatch = createEventDispatcher();
+
+	/** @param {string} optionValue */
+	function handleRelativeOptionClick(/** @type {string} */ optionValue) {
+		timeRange = optionValue;
+		startDate = '';
+		endDate = '';
+		showDatePicker = false;
+		dispatch('change', { timeRange, startDate, endDate });
+	}
+
+	function handleCustomConfirm() {
+		if (startDate) {
+			// If endDate is not provided, default to startDate
+			if (!endDate) {
+				endDate = startDate;
+			}
+			// Force reactivity by reassigning
+			timeRange = CUSTOM_DATE_RANGE;
+		}
+		showDatePicker = false;
+		dispatch('change', { timeRange, startDate, endDate });
+	}
+
+	function handleCancel() {
+		showDatePicker = false;
+	}
+</script>
+
+<div class="position-relative">
+	<button
+		type="button"
+		class="form-control text-start d-flex align-items-center justify-content-between"
+		on:click={() => {
+			showDatePicker = !showDatePicker;
+			if (showDatePicker) {
+				// If custom date is selected, switch to custom tab; otherwise use relative tab
+				datePickerTab = timeRange === CUSTOM_DATE_RANGE ? 'custom' : 'relative';
+			}
+		}}
+		style="cursor: pointer;"
+	>
+		<span>{timeRangeDisplayText || 'Select time range'}</span>
+		<i class="bx bx-chevron-down"></i>
+	</button>
+	{#if showDatePicker}
+		<div
+			bind:this={datePickerRef}
+			use:clickoutsideDirective
+			on:clickoutside={(/** @type {any} */ e) => {
+				if (e.detail && e.detail.targetNode && datePickerRef) {
+					if (!datePickerRef.contains(e.detail.targetNode)) {
+						showDatePicker = false;
+					}
+				}
+			}}
+			class="position-absolute top-100 start-0 mt-1 bg-white border rounded shadow-lg"
+			style="z-index: 1050; min-width: 320px; max-width: 350px;"
+		>
+			<ul class="nav nav-tabs border-bottom mb-0 px-2 pt-2" role="tablist">
+				<li class="nav-item flex-fill" role="presentation">
+					<button
+						class="nav-link fw-semibold {datePickerTab === 'relative' ? 'active text-primary' : 'text-muted'}"
+						type="button"
+						role="tab"
+						style="padding: 0.5rem 0.75rem; {datePickerTab === 'relative' ? 'border-bottom: 2px solid var(--bs-primary) !important; margin-bottom: -1px;' : ''}"
+						on:click={() => datePickerTab = 'relative'}
+					>
+						Relative
+					</button>
+				</li>
+				<li class="nav-item flex-fill" role="presentation">
+					<button
+						class="nav-link fw-semibold {datePickerTab === 'custom' ? 'active text-primary' : 'text-muted'}"
+						type="button"
+						role="tab"
+						style="padding: 0.5rem 0.75rem; {datePickerTab === 'custom' ? 'border-bottom: 2px solid var(--bs-primary) !important; margin-bottom: -1px;' : ''}"
+						on:click={() => {
+							datePickerTab = 'custom';
+							// Set default dates to yesterday and today if not already set
+							if (!startDate && !endDate) {
+								startDate = getYesterdayStr();
+								endDate = getTodayStr();
+							}
+						}}
+					>
+						Custom
+					</button>
+				</li>
+			</ul>
+			
+			<div class="p-4">
+				{#if datePickerTab === 'relative'}
+					<div class="d-flex flex-column gap-2" style="max-height: 300px; overflow-y: auto;">
+						{#each presetTimeRangeOptions as option}
+							<button
+								type="button"
+								class="btn btn-sm btn-outline-secondary text-start {timeRange === option.value ? 'active' : ''}"
+								on:click={(e) => {
+									e.preventDefault();
+									e.stopPropagation();
+									handleRelativeOptionClick(option.value);
+								}}
+							>
+								{option.label}
+							</button>
+						{/each}
+					</div>
+				{:else if datePickerTab === 'custom'}
+					<div class="mb-3">
+						<label for="start-date-picker" class="form-label small mb-2">From:</label>
+						<Input
+							id="start-date-picker"
+							type="date"
+							bind:value={startDate}
+							class="form-control form-control-sm"
+						/>
+					</div>
+					<div class="mb-4">
+						<label for="end-date-picker" class="form-label small mb-2">To:</label>
+						<Input
+							id="end-date-picker"
+							type="date"
+							bind:value={endDate}
+							class="form-control form-control-sm"
+						/>
+					</div>
+					<div class="d-flex justify-content-end gap-2 mt-3">
+						<Button
+							color="secondary"
+							size="sm"
+							type="button"
+							on:click={(e) => {
+								e.preventDefault();
+								e.stopPropagation();
+								handleCancel();
+							}}
+						>
+							Cancel
+						</Button>
+						<Button
+							color="primary"
+							size="sm"
+							type="button"
+							on:click={(e) => {
+								e.preventDefault();
+								e.stopPropagation();
+								handleCustomConfirm();
+							}}
+						>
+							Confirm
+						</Button>
+					</div>
+				{/if}
+			</div>
+		</div>
+	{/if}
+</div>

--- a/src/lib/helpers/constants.js
+++ b/src/lib/helpers/constants.js
@@ -49,6 +49,9 @@ export const IMAGE_DATA_PREFIX = 'data:image';
 export const INTEGER_REGEX = "[0-9]+";
 export const DECIMAL_REGEX = "[0-9.]+";
 
+// Custom date range identifier (not in TimeRange enum)
+export const CUSTOM_DATE_RANGE = "Custom date";
+
 export const TIME_RANGE_OPTIONS = [
     { label: TimeRange.Last15Minutes, value: TimeRange.Last15Minutes, qty: 15, unit: 'minutes' },
     { label: TimeRange.Last30Minutes, value: TimeRange.Last30Minutes, qty: 30, unit: 'minutes' },
@@ -57,7 +60,6 @@ export const TIME_RANGE_OPTIONS = [
     { label: TimeRange.Last12Hours, value: TimeRange.Last12Hours, qty: 12, unit: 'hours' },
     { label: TimeRange.Today, value: TimeRange.Today, qty: 1, unit: 'days' },
     { label: TimeRange.Yesterday, value: TimeRange.Yesterday, qty: 1, unit: 'days' },
-    { label: TimeRange.SpecificDay, value: TimeRange.SpecificDay, isSpecificDay: true },
     { label: TimeRange.Last3Days, value: TimeRange.Last3Days, qty: 3, unit: 'days' },
     { label: TimeRange.Last7Days, value: TimeRange.Last7Days, qty: 7, unit: 'days' },
     { label: TimeRange.Last30Days, value: TimeRange.Last30Days, qty: 30, unit: 'days' },

--- a/src/lib/helpers/enums.js
+++ b/src/lib/helpers/enums.js
@@ -257,7 +257,6 @@ const timeRange = {
     Last12Hours: "Last 12 hours",
     Today: "Today",
     Yesterday: "Yesterday",
-    SpecificDay: "Specific day",
     Last3Days: "Last 3 days",
     Last7Days: "Last 7 days",
     Last30Days: "Last 30 days",

--- a/src/lib/helpers/types/conversationTypes.js
+++ b/src/lib/helpers/types/conversationTypes.js
@@ -324,8 +324,8 @@ IRichContent.prototype.language;
  * @property {UserStateDetailModel[]} states
  * @property {string[]} tags
  * @property {string?} [timeRange]
- * @property {string} [startDate] - When timeRange is SpecificDay, start date in YYYY-MM-DD format (e.g. 2026-01-25)
- * @property {string} [endDate] - When timeRange is SpecificDay, end date in YYYY-MM-DD format (e.g. 2026-01-30). Defaults to startDate if not provided
+ * @property {string} [startDate] - When timeRange is "Custom date", start date in YYYY-MM-DD format (e.g. 2026-01-25)
+ * @property {string} [endDate] - When timeRange is "Custom date", end date in YYYY-MM-DD format (e.g. 2026-01-30). Defaults to startDate if not provided
  */
 
 /**

--- a/src/lib/helpers/types/conversationTypes.js
+++ b/src/lib/helpers/types/conversationTypes.js
@@ -324,7 +324,8 @@ IRichContent.prototype.language;
  * @property {UserStateDetailModel[]} states
  * @property {string[]} tags
  * @property {string?} [timeRange]
- * @property {string} [specificDate] - When timeRange is SpecificDay, date in YYYY-MM-DD (e.g. 2026-01-25)
+ * @property {string} [startDate] - When timeRange is SpecificDay, start date in YYYY-MM-DD format (e.g. 2026-01-25)
+ * @property {string} [endDate] - When timeRange is SpecificDay, end date in YYYY-MM-DD format (e.g. 2026-01-30). Defaults to startDate if not provided
  */
 
 /**

--- a/src/lib/helpers/utils/common.js
+++ b/src/lib/helpers/utils/common.js
@@ -192,10 +192,11 @@ export function getCleanUrl(url) {
 
 /**
  * @param {string} timeRange
- * @param {string} [specificDate] - When timeRange is SpecificDay, date in YYYY-MM-DD format (e.g. 2026-01-25)
+ * @param {string} [startDate] - When timeRange is SpecificDay, start date in YYYY-MM-DD format (e.g. 2026-01-25)
+ * @param {string} [endDate] - When timeRange is SpecificDay, end date in YYYY-MM-DD format (e.g. 2026-01-30). If not provided, uses startDate
  * @returns {{ startTime: string | null, endTime: string | null }}
  */
-export function convertTimeRange(timeRange, specificDate) {
+export function convertTimeRange(timeRange, startDate, endDate) {
     let ret = { startTime: null, endTime: null };
 
     if (!timeRange) {
@@ -242,13 +243,14 @@ export function convertTimeRange(timeRange, specificDate) {
             };
             break;
         case TimeRange.SpecificDay:
-            if (specificDate && moment(specificDate).isValid()) {
+            if (startDate && moment(startDate).isValid()) {
+                const endDateToUse = endDate && moment(endDate).isValid() ? endDate : startDate;
                 ret = {
                     ...ret,
                     // @ts-ignore
-                    startTime: moment(specificDate).startOf('day').utc().format(),
+                    startTime: moment(startDate).startOf('day').utc().format(),
                     // @ts-ignore
-                    endTime: moment(specificDate).endOf('day').utc().format()
+                    endTime: moment(endDateToUse).endOf('day').utc().format()
                 };
             }
             break;

--- a/src/lib/helpers/utils/common.js
+++ b/src/lib/helpers/utils/common.js
@@ -1,6 +1,6 @@
 import { goto } from '$app/navigation';
 import moment from 'moment';
-import { TIME_RANGE_OPTIONS } from '../constants';
+import { TIME_RANGE_OPTIONS, CUSTOM_DATE_RANGE } from '../constants';
 import { TimeRange } from '../enums';
 
 export function range(size = 3, startAt = 0) {
@@ -192,8 +192,8 @@ export function getCleanUrl(url) {
 
 /**
  * @param {string} timeRange
- * @param {string} [startDate] - When timeRange is SpecificDay, start date in YYYY-MM-DD format (e.g. 2026-01-25)
- * @param {string} [endDate] - When timeRange is SpecificDay, end date in YYYY-MM-DD format (e.g. 2026-01-30). If not provided, uses startDate
+ * @param {string} [startDate] - When timeRange is "Custom date", start date in YYYY-MM-DD format (e.g. 2026-01-25)
+ * @param {string} [endDate] - When timeRange is "Custom date", end date in YYYY-MM-DD format (e.g. 2026-01-30). If not provided, uses startDate
  * @returns {{ startTime: string | null, endTime: string | null }}
  */
 export function convertTimeRange(timeRange, startDate, endDate) {
@@ -242,7 +242,7 @@ export function convertTimeRange(timeRange, startDate, endDate) {
                 endTime: moment().subtract(1, 'days').endOf('day').utc().format()
             };
             break;
-        case TimeRange.SpecificDay:
+        case CUSTOM_DATE_RANGE:
             if (startDate && moment(startDate).isValid()) {
                 const endDateToUse = endDate && moment(endDate).isValid() ? endDate : startDate;
                 ret = {

--- a/src/routes/page/conversation/+page.svelte
+++ b/src/routes/page/conversation/+page.svelte
@@ -23,7 +23,6 @@
 	import { getAgentOptions } from '$lib/services/agent-service';
 	import { utcToLocal } from '$lib/helpers/datetime';
 	import { ConversationChannel, TimeRange } from '$lib/helpers/enums';
-	import { CUSTOM_DATE_RANGE } from '$lib/helpers/constants';
 	import {
 		getConversations,
 		deleteConversation,
@@ -510,12 +509,10 @@
 							bind:startDate={searchOption.startDate}
 							bind:endDate={searchOption.endDate}
 							on:change={(e) => {
+								// Only update searchOption, don't trigger query immediately
 								searchOption.timeRange = e.detail.timeRange;
 								searchOption.startDate = e.detail.startDate;
 								searchOption.endDate = e.detail.endDate;
-								refreshFilter();
-								initFilterPager();
-								getPagedConversations();
 							}}
 						/>
 					</Col>

--- a/src/routes/page/conversation/+page.svelte
+++ b/src/routes/page/conversation/+page.svelte
@@ -19,11 +19,11 @@
 	import TablePagination from '$lib/common/shared/TablePagination.svelte';
 	import LoadingToComplete from '$lib/common/spinners/LoadingToComplete.svelte';
 	import Select from '$lib/common/dropdowns/Select.svelte';
+	import TimeRangePicker from '$lib/common/shared/TimeRangePicker.svelte';
 	import { getAgentOptions } from '$lib/services/agent-service';
 	import { utcToLocal } from '$lib/helpers/datetime';
 	import { ConversationChannel, TimeRange } from '$lib/helpers/enums';
-	import { TIME_RANGE_OPTIONS, CUSTOM_DATE_RANGE } from '$lib/helpers/constants';
-	import { clickoutsideDirective } from '$lib/helpers/directives';
+	import { CUSTOM_DATE_RANGE } from '$lib/helpers/constants';
 	import {
 		getConversations,
 		deleteConversation,
@@ -41,76 +41,11 @@
 	const firstPage = 1;
 	const pageSize = 15;
 
-	// Get today's date in YYYY-MM-DD format
-	const getTodayStr = () => {
-		const d = new Date();
-		return d.getFullYear() + '-' + String(d.getMonth() + 1).padStart(2, '0') + '-' + String(d.getDate()).padStart(2, '0');
-	};
-
-	// Get yesterday's date in YYYY-MM-DD format
-	const getYesterdayStr = () => {
-		const d = new Date();
-		d.setDate(d.getDate() - 1);
-		return d.getFullYear() + '-' + String(d.getMonth() + 1).padStart(2, '0') + '-' + String(d.getDate()).padStart(2, '0');
-	};
-
-	// Format date for display (YYYY-MM-DD -> MM/DD/YYYY)
-	const formatDateForDisplay = (/** @type {string} */ dateStr) => {
-		if (!dateStr) return '';
-		const [year, month, day] = dateStr.split('-');
-		return `${month}/${day}/${year}`;
-	};
-
-	// Get time range display text
-	const getTimeRangeDisplayText = () => {
-		if (searchOption.timeRange === CUSTOM_DATE_RANGE) {
-			if (searchOption.startDate && searchOption.endDate) {
-				const start = formatDateForDisplay(searchOption.startDate);
-				const end = formatDateForDisplay(searchOption.endDate);
-				if (start === end) {
-					return start;
-				}
-				return `${start} - ${end}`;
-			}
-			return 'Custom';
-		}
-		// Find the label for the selected time range
-		const selected = presetTimeRangeOptions.find(x => x.value === searchOption.timeRange);
-		return selected ? selected.label : '';
-	};
-
 	/** @type {boolean} */
 	let isLoading = false;
 	let isComplete = false;
 	let showStateSearch = false;
 	let isPageMounted = false;
-
-	/** @type {boolean} */
-	let showDatePicker = false;
-
-	/** @type {HTMLDivElement | null} */
-	let datePickerRef = null;
-
-	/** @type {string} */
-	let timeRangeDisplayText = '';
-
-	// Update time range display text reactively
-	$: {
-		if (searchOption.timeRange === CUSTOM_DATE_RANGE && searchOption.startDate && searchOption.endDate) {
-			const start = formatDateForDisplay(searchOption.startDate);
-			const end = formatDateForDisplay(searchOption.endDate);
-			if (start === end) {
-				timeRangeDisplayText = start;
-			} else {
-				timeRangeDisplayText = `${start} - ${end}`;
-			}
-		} else if (searchOption.timeRange === CUSTOM_DATE_RANGE) {
-			timeRangeDisplayText = 'Custom';
-		} else {
-			const selected = presetTimeRangeOptions.find(x => x.value === searchOption.timeRange);
-			timeRangeDisplayText = selected ? selected.label : '';
-		}
-	}
 
     /** @type {import('$commonTypes').PagedItems<import('$conversationTypes').ConversationModel>} */
     let conversations = { count: 0, items: [] };
@@ -143,14 +78,6 @@
 		{ value: k.toLowerCase(), label: v }
 	));
 
-	// Preset time range options
-	const presetTimeRangeOptions = TIME_RANGE_OPTIONS.map(x => ({
-			label: x.label,
-			value: x.value
-		}));
-
-	/** @type {string} */
-	let datePickerTab = 'relative';
 
 	/** @type {{ startTime: string | null, endTime: string | null }} */
 	let innerTimeRange = {
@@ -577,154 +504,20 @@
 							on:input={e => changeOption(e, "tags")}
 						/>
 					</Col>
-					<Col lg="2" class="position-relative">
-						<button
-							type="button"
-							class="form-control text-start d-flex align-items-center justify-content-between"
-							on:click={() => {
-								showDatePicker = !showDatePicker;
-								if (showDatePicker) {
-									// If custom date is selected, switch to custom tab; otherwise use relative tab
-									datePickerTab = searchOption.timeRange === CUSTOM_DATE_RANGE ? 'custom' : 'relative';
-								}
+					<Col lg="2">
+						<TimeRangePicker
+							bind:timeRange={searchOption.timeRange}
+							bind:startDate={searchOption.startDate}
+							bind:endDate={searchOption.endDate}
+							on:change={(e) => {
+								searchOption.timeRange = e.detail.timeRange;
+								searchOption.startDate = e.detail.startDate;
+								searchOption.endDate = e.detail.endDate;
+								refreshFilter();
+								initFilterPager();
+								getPagedConversations();
 							}}
-							style="cursor: pointer;"
-						>
-							<span>{timeRangeDisplayText || 'Select time range'}</span>
-							<i class="bx bx-chevron-down"></i>
-						</button>
-						{#if showDatePicker}
-							<div
-								bind:this={datePickerRef}
-								use:clickoutsideDirective
-								on:clickoutside={(/** @type {any} */ e) => {
-									if (e.detail && e.detail.targetNode && datePickerRef) {
-										if (!datePickerRef.contains(e.detail.targetNode)) {
-											showDatePicker = false;
-										}
-									}
-								}}
-								class="position-absolute top-100 start-0 mt-1 bg-white border rounded shadow-lg"
-								style="z-index: 1050; min-width: 320px; max-width: 350px;"
-							>
-								<ul class="nav nav-tabs border-bottom mb-0 px-2 pt-2" role="tablist">
-									<li class="nav-item flex-fill" role="presentation">
-										<button
-											class="nav-link fw-semibold {datePickerTab === 'relative' ? 'active text-primary' : 'text-muted'}"
-											type="button"
-											role="tab"
-											style="padding: 0.5rem 0.75rem; {datePickerTab === 'relative' ? 'border-bottom: 2px solid var(--bs-primary) !important; margin-bottom: -1px;' : ''}"
-											on:click={() => datePickerTab = 'relative'}
-										>
-											Relative
-										</button>
-									</li>
-									<li class="nav-item flex-fill" role="presentation">
-										<button
-											class="nav-link fw-semibold {datePickerTab === 'custom' ? 'active text-primary' : 'text-muted'}"
-											type="button"
-											role="tab"
-											style="padding: 0.5rem 0.75rem; {datePickerTab === 'custom' ? 'border-bottom: 2px solid var(--bs-primary) !important; margin-bottom: -1px;' : ''}"
-											on:click={() => {
-												datePickerTab = 'custom';
-												// Set default dates to yesterday and today if not already set
-												if (!searchOption.startDate && !searchOption.endDate) {
-													searchOption.startDate = getYesterdayStr();
-													searchOption.endDate = getTodayStr();
-												}
-											}}
-										>
-											Custom
-										</button>
-									</li>
-								</ul>
-								
-								<div class="p-4">
-									{#if datePickerTab === 'relative'}
-										<div class="d-flex flex-column gap-2" style="max-height: 300px; overflow-y: auto;">
-											{#each presetTimeRangeOptions as option}
-												<button
-													type="button"
-													class="btn btn-sm btn-outline-secondary text-start {searchOption.timeRange === option.value ? 'active' : ''}"
-													on:click={(e) => {
-														e.preventDefault();
-														e.stopPropagation();
-														searchOption.timeRange = option.value;
-														searchOption.startDate = '';
-														searchOption.endDate = '';
-														showDatePicker = false;
-														refreshFilter();
-														initFilterPager();
-														getPagedConversations();
-													}}
-												>
-													{option.label}
-												</button>
-											{/each}
-										</div>
-									{:else if datePickerTab === 'custom'}
-										<div class="mb-3">
-											<label for="start-date-picker" class="form-label small mb-2">From:</label>
-											<Input
-												id="start-date-picker"
-												type="date"
-												bind:value={searchOption.startDate}
-												class="form-control form-control-sm"
-											/>
-										</div>
-										<div class="mb-4">
-											<label for="end-date-picker" class="form-label small mb-2">To:</label>
-											<Input
-												id="end-date-picker"
-												type="date"
-												bind:value={searchOption.endDate}
-												class="form-control form-control-sm"
-											/>
-										</div>
-										<div class="d-flex justify-content-end gap-2 mt-3">
-											<Button
-												color="secondary"
-												size="sm"
-												type="button"
-												on:click={(e) => {
-													e.preventDefault();
-													e.stopPropagation();
-													showDatePicker = false;
-												}}
-											>
-												Cancel
-											</Button>
-											<Button
-												color="primary"
-												size="sm"
-												type="button"
-												on:click={(e) => {
-													e.preventDefault();
-													e.stopPropagation();
-													if (searchOption.startDate) {
-														// If endDate is not provided, default to startDate
-														if (!searchOption.endDate) {
-															searchOption.endDate = searchOption.startDate;
-														}
-														// Force reactivity by reassigning the object
-														searchOption = {
-															...searchOption,
-															timeRange: CUSTOM_DATE_RANGE
-														};
-													}
-													showDatePicker = false;
-													refreshFilter();
-													initFilterPager();
-													getPagedConversations();
-												}}
-											>
-												Confirm
-											</Button>
-										</div>
-									{/if}
-								</div>
-							</div>
-						{/if}
+						/>
 					</Col>
 					<Col lg="1">
 						<Button

--- a/src/routes/page/conversation/+page.svelte
+++ b/src/routes/page/conversation/+page.svelte
@@ -22,7 +22,7 @@
 	import { getAgentOptions } from '$lib/services/agent-service';
 	import { utcToLocal } from '$lib/helpers/datetime';
 	import { ConversationChannel, TimeRange } from '$lib/helpers/enums';
-	import { TIME_RANGE_OPTIONS } from '$lib/helpers/constants';
+	import { TIME_RANGE_OPTIONS, CUSTOM_DATE_RANGE } from '$lib/helpers/constants';
 	import { clickoutsideDirective } from '$lib/helpers/directives';
 	import {
 		getConversations,
@@ -63,7 +63,7 @@
 
 	// Get time range display text
 	const getTimeRangeDisplayText = () => {
-		if (searchOption.timeRange === TimeRange.SpecificDay) {
+		if (searchOption.timeRange === CUSTOM_DATE_RANGE) {
 			if (searchOption.startDate && searchOption.endDate) {
 				const start = formatDateForDisplay(searchOption.startDate);
 				const end = formatDateForDisplay(searchOption.endDate);
@@ -96,7 +96,7 @@
 
 	// Update time range display text reactively
 	$: {
-		if (searchOption.timeRange === TimeRange.SpecificDay && searchOption.startDate && searchOption.endDate) {
+		if (searchOption.timeRange === CUSTOM_DATE_RANGE && searchOption.startDate && searchOption.endDate) {
 			const start = formatDateForDisplay(searchOption.startDate);
 			const end = formatDateForDisplay(searchOption.endDate);
 			if (start === end) {
@@ -104,7 +104,7 @@
 			} else {
 				timeRangeDisplayText = `${start} - ${end}`;
 			}
-		} else if (searchOption.timeRange === TimeRange.SpecificDay) {
+		} else if (searchOption.timeRange === CUSTOM_DATE_RANGE) {
 			timeRangeDisplayText = 'Custom';
 		} else {
 			const selected = presetTimeRangeOptions.find(x => x.value === searchOption.timeRange);
@@ -143,9 +143,9 @@
 		{ value: k.toLowerCase(), label: v }
 	));
 
-	// Preset time range options (excluding SpecificDay)
+	// Preset time range options (excluding custom date)
 	const presetTimeRangeOptions = TIME_RANGE_OPTIONS
-		.filter(x => x.value !== TimeRange.SpecificDay)
+		.filter(x => x.value !== CUSTOM_DATE_RANGE)
 		.map(x => ({
 			label: x.label,
 			value: x.value
@@ -586,7 +586,8 @@
 							on:click={() => {
 								showDatePicker = !showDatePicker;
 								if (showDatePicker) {
-									datePickerTab = 'relative';
+									// If custom date is selected, switch to custom tab; otherwise use relative tab
+									datePickerTab = searchOption.timeRange === CUSTOM_DATE_RANGE ? 'custom' : 'relative';
 								}
 							}}
 							style="cursor: pointer;"
@@ -710,7 +711,7 @@
 														// Force reactivity by reassigning the object
 														searchOption = {
 															...searchOption,
-															timeRange: TimeRange.SpecificDay
+															timeRange: CUSTOM_DATE_RANGE
 														};
 													}
 													showDatePicker = false;

--- a/src/routes/page/conversation/+page.svelte
+++ b/src/routes/page/conversation/+page.svelte
@@ -143,10 +143,8 @@
 		{ value: k.toLowerCase(), label: v }
 	));
 
-	// Preset time range options (excluding custom date)
-	const presetTimeRangeOptions = TIME_RANGE_OPTIONS
-		.filter(x => x.value !== CUSTOM_DATE_RANGE)
-		.map(x => ({
+	// Preset time range options
+	const presetTimeRangeOptions = TIME_RANGE_OPTIONS.map(x => ({
 			label: x.label,
 			value: x.value
 		}));

--- a/src/routes/page/instruction/log/+page.svelte
+++ b/src/routes/page/instruction/log/+page.svelte
@@ -15,14 +15,13 @@
 	import { convertTimeRange, removeDuplicates } from '$lib/helpers/utils/common';
 	import StateSearch from '$lib/common/shared/StateSearch.svelte';
 	import Select from '$lib/common/dropdowns/Select.svelte';
+	import TimeRangePicker from '$lib/common/shared/TimeRangePicker.svelte';
 	import {
 		getPagingQueryParams,
 		setUrlQueryParams,
 		goToUrl
 	} from '$lib/helpers/utils/common';
 	import { TimeRange } from '$lib/helpers/enums';
-	import { TIME_RANGE_OPTIONS, CUSTOM_DATE_RANGE } from '$lib/helpers/constants';
-	import { clickoutsideDirective } from '$lib/helpers/directives';
 	import LogItem from './log-item.svelte';
 
     const firstPage = 1;
@@ -31,53 +30,6 @@
 	let isPageMounted = false;
 
     const initPager = { page: firstPage, size: pageSize };
-
-	// Preset time range options
-	const presetTimeRangeOptions = TIME_RANGE_OPTIONS.map(x => ({
-			label: x.label,
-			value: x.value
-		}));
-
-	/** @type {string} */
-	let datePickerTab = 'relative';
-
-	// Get today's date in YYYY-MM-DD format
-	const getTodayStr = () => {
-		const d = new Date();
-		return d.getFullYear() + '-' + String(d.getMonth() + 1).padStart(2, '0') + '-' + String(d.getDate()).padStart(2, '0');
-	};
-
-	// Get yesterday's date in YYYY-MM-DD format
-	const getYesterdayStr = () => {
-		const d = new Date();
-		d.setDate(d.getDate() - 1);
-		return d.getFullYear() + '-' + String(d.getMonth() + 1).padStart(2, '0') + '-' + String(d.getDate()).padStart(2, '0');
-	};
-
-	// Format date for display (YYYY-MM-DD -> MM/DD/YYYY)
-	const formatDateForDisplay = (/** @type {string} */ dateStr) => {
-		if (!dateStr) return '';
-		const [year, month, day] = dateStr.split('-');
-		return `${month}/${day}/${year}`;
-	};
-
-	// Get time range display text
-	const getTimeRangeDisplayText = () => {
-		if (searchOption.timeRange === CUSTOM_DATE_RANGE) {
-			if (searchOption.startDate && searchOption.endDate) {
-				const start = formatDateForDisplay(searchOption.startDate);
-				const end = formatDateForDisplay(searchOption.endDate);
-				if (start === end) {
-					return start;
-				}
-				return `${start} - ${end}`;
-			}
-			return 'Custom';
-		}
-		// Find the label for the selected time range
-		const selected = presetTimeRangeOptions.find(x => x.value === searchOption.timeRange);
-		return selected ? selected.label : '';
-	};
 
     /** @type {import('$commonTypes').Pagination} */
 	let pager = { page: firstPage, size: pageSize, count: 0 }
@@ -121,32 +73,6 @@
 	/** @type {boolean} */
 	let showStateSearch = false;
 
-	/** @type {string} */
-	let timeRangeDisplayText = '';
-
-	// Update time range display text reactively
-	$: {
-		if (searchOption.timeRange === CUSTOM_DATE_RANGE && searchOption.startDate && searchOption.endDate) {
-			const start = formatDateForDisplay(searchOption.startDate);
-			const end = formatDateForDisplay(searchOption.endDate);
-			if (start === end) {
-				timeRangeDisplayText = start;
-			} else {
-				timeRangeDisplayText = `${start} - ${end}`;
-			}
-		} else if (searchOption.timeRange === CUSTOM_DATE_RANGE) {
-			timeRangeDisplayText = 'Custom';
-		} else {
-			const selected = presetTimeRangeOptions.find(x => x.value === searchOption.timeRange);
-			timeRangeDisplayText = selected ? selected.label : '';
-		}
-	}
-
-	/** @type {boolean} */
-	let showDatePicker = false;
-
-	/** @type {HTMLDivElement | null} */
-	let datePickerRef = null;
 
 	/** @type {{key: string, value: string | null}[]} */
     let states = [
@@ -442,150 +368,18 @@
 					<Col lg="2">
 						<Input bind:value={searchOption.template} maxlength={100} placeholder={'Search template...'} />
 					</Col>
-					<Col lg="2" class="position-relative">
-						<button
-							type="button"
-							class="form-control text-start d-flex align-items-center justify-content-between"
-							on:click={() => {
-								showDatePicker = !showDatePicker;
-								if (showDatePicker) {
-									// If custom date is selected, switch to custom tab; otherwise use relative tab
-									datePickerTab = searchOption.timeRange === CUSTOM_DATE_RANGE ? 'custom' : 'relative';
-								}
+					<Col lg="2">
+						<TimeRangePicker
+							bind:timeRange={searchOption.timeRange}
+							bind:startDate={searchOption.startDate}
+							bind:endDate={searchOption.endDate}
+							on:change={(e) => {
+								searchOption.timeRange = e.detail.timeRange;
+								searchOption.startDate = e.detail.startDate;
+								searchOption.endDate = e.detail.endDate;
+								search();
 							}}
-							style="cursor: pointer;"
-						>
-							<span>{timeRangeDisplayText || 'Select time range'}</span>
-							<i class="bx bx-chevron-down"></i>
-						</button>
-						{#if showDatePicker}
-							<div
-								bind:this={datePickerRef}
-								use:clickoutsideDirective
-								on:clickoutside={(/** @type {any} */ e) => {
-									if (e.detail && e.detail.targetNode && datePickerRef) {
-										if (!datePickerRef.contains(e.detail.targetNode)) {
-											showDatePicker = false;
-										}
-									}
-								}}
-								class="position-absolute top-100 start-0 mt-1 bg-white border rounded shadow-lg"
-								style="z-index: 1050; min-width: 320px; max-width: 350px;"
-							>
-								<ul class="nav nav-tabs border-bottom mb-0 px-2 pt-2" role="tablist">
-									<li class="nav-item flex-fill" role="presentation">
-										<button
-											class="nav-link fw-semibold {datePickerTab === 'relative' ? 'active text-primary' : 'text-muted'}"
-											type="button"
-											role="tab"
-											style="padding: 0.5rem 0.75rem; {datePickerTab === 'relative' ? 'border-bottom: 2px solid var(--bs-primary) !important; margin-bottom: -1px;' : ''}"
-											on:click={() => datePickerTab = 'relative'}
-										>
-											Relative
-										</button>
-									</li>
-									<li class="nav-item flex-fill" role="presentation">
-										<button
-											class="nav-link fw-semibold {datePickerTab === 'custom' ? 'active text-primary' : 'text-muted'}"
-											type="button"
-											role="tab"
-											style="padding: 0.5rem 0.75rem; {datePickerTab === 'custom' ? 'border-bottom: 2px solid var(--bs-primary) !important; margin-bottom: -1px;' : ''}"
-											on:click={() => {
-												datePickerTab = 'custom';
-												// Set default dates to yesterday and today if not already set
-												if (!searchOption.startDate && !searchOption.endDate) {
-													searchOption.startDate = getYesterdayStr();
-													searchOption.endDate = getTodayStr();
-												}
-											}}
-										>
-											Custom
-										</button>
-									</li>
-								</ul>
-								
-								<div class="p-4">
-									{#if datePickerTab === 'relative'}
-										<div class="d-flex flex-column gap-2" style="max-height: 300px; overflow-y: auto;">
-											{#each presetTimeRangeOptions as option}
-												<button
-													type="button"
-													class="btn btn-sm btn-outline-secondary text-start {searchOption.timeRange === option.value ? 'active' : ''}"
-													on:click={(e) => {
-														e.preventDefault();
-														e.stopPropagation();
-														searchOption.timeRange = option.value;
-														searchOption.startDate = '';
-														searchOption.endDate = '';
-														showDatePicker = false;
-														search();
-													}}
-												>
-													{option.label}
-												</button>
-											{/each}
-										</div>
-									{:else if datePickerTab === 'custom'}
-										<div class="mb-3">
-											<label for="start-date-picker-log" class="form-label small mb-2">From:</label>
-											<Input
-												id="start-date-picker-log"
-												type="date"
-												bind:value={searchOption.startDate}
-												class="form-control form-control-sm"
-											/>
-										</div>
-										<div class="mb-4">
-											<label for="end-date-picker-log" class="form-label small mb-2">To:</label>
-											<Input
-												id="end-date-picker-log"
-												type="date"
-												bind:value={searchOption.endDate}
-												class="form-control form-control-sm"
-											/>
-										</div>
-										<div class="d-flex justify-content-end gap-2 mt-3">
-											<Button
-												color="secondary"
-												size="sm"
-												type="button"
-												on:click={(e) => {
-													e.preventDefault();
-													e.stopPropagation();
-													showDatePicker = false;
-												}}
-											>
-												Cancel
-											</Button>
-											<Button
-												color="primary"
-												size="sm"
-												type="button"
-												on:click={(e) => {
-													e.preventDefault();
-													e.stopPropagation();
-													if (searchOption.startDate) {
-														// If endDate is not provided, default to startDate
-														if (!searchOption.endDate) {
-															searchOption.endDate = searchOption.startDate;
-														}
-														// Force reactivity by reassigning the object
-														searchOption = {
-															...searchOption,
-															timeRange: CUSTOM_DATE_RANGE
-														};
-													}
-													showDatePicker = false;
-													search();
-												}}
-											>
-												Confirm
-											</Button>
-										</div>
-									{/if}
-								</div>
-							</div>
-						{/if}
+						/>
 					</Col>
 					<Col lg="1">
 						<Button

--- a/src/routes/page/instruction/log/+page.svelte
+++ b/src/routes/page/instruction/log/+page.svelte
@@ -32,10 +32,8 @@
 
     const initPager = { page: firstPage, size: pageSize };
 
-	// Preset time range options (excluding custom date)
-	const presetTimeRangeOptions = TIME_RANGE_OPTIONS
-		.filter(x => x.value !== CUSTOM_DATE_RANGE)
-		.map(x => ({
+	// Preset time range options
+	const presetTimeRangeOptions = TIME_RANGE_OPTIONS.map(x => ({
 			label: x.label,
 			value: x.value
 		}));

--- a/src/routes/page/instruction/log/+page.svelte
+++ b/src/routes/page/instruction/log/+page.svelte
@@ -21,7 +21,7 @@
 		goToUrl
 	} from '$lib/helpers/utils/common';
 	import { TimeRange } from '$lib/helpers/enums';
-	import { TIME_RANGE_OPTIONS } from '$lib/helpers/constants';
+	import { TIME_RANGE_OPTIONS, CUSTOM_DATE_RANGE } from '$lib/helpers/constants';
 	import { clickoutsideDirective } from '$lib/helpers/directives';
 	import LogItem from './log-item.svelte';
 
@@ -32,9 +32,9 @@
 
     const initPager = { page: firstPage, size: pageSize };
 
-	// Preset time range options (excluding SpecificDay)
+	// Preset time range options (excluding custom date)
 	const presetTimeRangeOptions = TIME_RANGE_OPTIONS
-		.filter(x => x.value !== TimeRange.SpecificDay)
+		.filter(x => x.value !== CUSTOM_DATE_RANGE)
 		.map(x => ({
 			label: x.label,
 			value: x.value
@@ -65,7 +65,7 @@
 
 	// Get time range display text
 	const getTimeRangeDisplayText = () => {
-		if (searchOption.timeRange === TimeRange.SpecificDay) {
+		if (searchOption.timeRange === CUSTOM_DATE_RANGE) {
 			if (searchOption.startDate && searchOption.endDate) {
 				const start = formatDateForDisplay(searchOption.startDate);
 				const end = formatDateForDisplay(searchOption.endDate);
@@ -128,7 +128,7 @@
 
 	// Update time range display text reactively
 	$: {
-		if (searchOption.timeRange === TimeRange.SpecificDay && searchOption.startDate && searchOption.endDate) {
+		if (searchOption.timeRange === CUSTOM_DATE_RANGE && searchOption.startDate && searchOption.endDate) {
 			const start = formatDateForDisplay(searchOption.startDate);
 			const end = formatDateForDisplay(searchOption.endDate);
 			if (start === end) {
@@ -136,7 +136,7 @@
 			} else {
 				timeRangeDisplayText = `${start} - ${end}`;
 			}
-		} else if (searchOption.timeRange === TimeRange.SpecificDay) {
+		} else if (searchOption.timeRange === CUSTOM_DATE_RANGE) {
 			timeRangeDisplayText = 'Custom';
 		} else {
 			const selected = presetTimeRangeOptions.find(x => x.value === searchOption.timeRange);
@@ -451,7 +451,8 @@
 							on:click={() => {
 								showDatePicker = !showDatePicker;
 								if (showDatePicker) {
-									datePickerTab = 'relative';
+									// If custom date is selected, switch to custom tab; otherwise use relative tab
+									datePickerTab = searchOption.timeRange === CUSTOM_DATE_RANGE ? 'custom' : 'relative';
 								}
 							}}
 							style="cursor: pointer;"
@@ -573,7 +574,7 @@
 														// Force reactivity by reassigning the object
 														searchOption = {
 															...searchOption,
-															timeRange: TimeRange.SpecificDay
+															timeRange: CUSTOM_DATE_RANGE
 														};
 													}
 													showDatePicker = false;

--- a/src/routes/page/instruction/log/+page.svelte
+++ b/src/routes/page/instruction/log/+page.svelte
@@ -22,6 +22,7 @@
 	} from '$lib/helpers/utils/common';
 	import { TimeRange } from '$lib/helpers/enums';
 	import { TIME_RANGE_OPTIONS } from '$lib/helpers/constants';
+	import { clickoutsideDirective } from '$lib/helpers/directives';
 	import LogItem from './log-item.svelte';
 
     const firstPage = 1;
@@ -31,15 +32,53 @@
 
     const initPager = { page: firstPage, size: pageSize };
 
-	const timeRangeOptions = TIME_RANGE_OPTIONS.map(x => ({
-		label: x.label,
-		value: x.value
-	}));
+	// Preset time range options (excluding SpecificDay)
+	const presetTimeRangeOptions = TIME_RANGE_OPTIONS
+		.filter(x => x.value !== TimeRange.SpecificDay)
+		.map(x => ({
+			label: x.label,
+			value: x.value
+		}));
+
+	/** @type {string} */
+	let datePickerTab = 'relative';
 
 	// Get today's date in YYYY-MM-DD format
 	const getTodayStr = () => {
 		const d = new Date();
 		return d.getFullYear() + '-' + String(d.getMonth() + 1).padStart(2, '0') + '-' + String(d.getDate()).padStart(2, '0');
+	};
+
+	// Get yesterday's date in YYYY-MM-DD format
+	const getYesterdayStr = () => {
+		const d = new Date();
+		d.setDate(d.getDate() - 1);
+		return d.getFullYear() + '-' + String(d.getMonth() + 1).padStart(2, '0') + '-' + String(d.getDate()).padStart(2, '0');
+	};
+
+	// Format date for display (YYYY-MM-DD -> MM/DD/YYYY)
+	const formatDateForDisplay = (/** @type {string} */ dateStr) => {
+		if (!dateStr) return '';
+		const [year, month, day] = dateStr.split('-');
+		return `${month}/${day}/${year}`;
+	};
+
+	// Get time range display text
+	const getTimeRangeDisplayText = () => {
+		if (searchOption.timeRange === TimeRange.SpecificDay) {
+			if (searchOption.startDate && searchOption.endDate) {
+				const start = formatDateForDisplay(searchOption.startDate);
+				const end = formatDateForDisplay(searchOption.endDate);
+				if (start === end) {
+					return start;
+				}
+				return `${start} - ${end}`;
+			}
+			return 'Custom';
+		}
+		// Find the label for the selected time range
+		const selected = presetTimeRangeOptions.find(x => x.value === searchOption.timeRange);
+		return selected ? selected.label : '';
 	};
 
     /** @type {import('$commonTypes').Pagination} */
@@ -70,7 +109,8 @@
 		models: [],
         template: '',
 		timeRange: TimeRange.Today,
-		specificDate: '',
+		startDate: '',
+		endDate: '',
 		states: []
 	};
 
@@ -83,6 +123,33 @@
 	/** @type {boolean} */
 	let showStateSearch = false;
 
+	/** @type {string} */
+	let timeRangeDisplayText = '';
+
+	// Update time range display text reactively
+	$: {
+		if (searchOption.timeRange === TimeRange.SpecificDay && searchOption.startDate && searchOption.endDate) {
+			const start = formatDateForDisplay(searchOption.startDate);
+			const end = formatDateForDisplay(searchOption.endDate);
+			if (start === end) {
+				timeRangeDisplayText = start;
+			} else {
+				timeRangeDisplayText = `${start} - ${end}`;
+			}
+		} else if (searchOption.timeRange === TimeRange.SpecificDay) {
+			timeRangeDisplayText = 'Custom';
+		} else {
+			const selected = presetTimeRangeOptions.find(x => x.value === searchOption.timeRange);
+			timeRangeDisplayText = selected ? selected.label : '';
+		}
+	}
+
+	/** @type {boolean} */
+	let showDatePicker = false;
+
+	/** @type {HTMLDivElement | null} */
+	let datePickerRef = null;
+
 	/** @type {{key: string, value: string | null}[]} */
     let states = [
         { key: '', value: ''}
@@ -94,7 +161,7 @@
 			page: $page.url.searchParams.get("page"),
 			pageSize: $page.url.searchParams.get("pageSize")
 		}, { defaultPageSize: pageSize });
-		innerTimeRange = convertTimeRange(searchOption.timeRange, searchOption.specificDate);
+		innerTimeRange = convertTimeRange(searchOption.timeRange, searchOption.startDate, searchOption.endDate);
 
 		filter = {
 			...filter,
@@ -230,13 +297,7 @@
 				models: selectedValues
 			};
         } else if (type === 'timeRange') {
-			const timeRange = selectedValues.length > 0 ? selectedValues[0] : null;
-			const isSpecificDay = timeRange === TimeRange.SpecificDay;
-			searchOption = {
-				...searchOption,
-				timeRange,
-				specificDate: isSpecificDay ? (searchOption.specificDate || getTodayStr()) : ''
-			};
+			// This handler is no longer used, but kept for compatibility
 		}
 	}
 
@@ -252,7 +313,7 @@
         const models = searchOption.models;
         const template = util.trim(searchOption.template) || null;
 		const states = getSearchStates();
-		innerTimeRange = convertTimeRange(searchOption.timeRange, searchOption.specificDate);
+		innerTimeRange = convertTimeRange(searchOption.timeRange, searchOption.startDate, searchOption.endDate);
 
         filter = {
             ...filter,
@@ -383,21 +444,148 @@
 					<Col lg="2">
 						<Input bind:value={searchOption.template} maxlength={100} placeholder={'Search template...'} />
 					</Col>
-					<Col lg="2">
-						<Select
-							tag={'instruct-datetime-select'}
-							placeholder={'Select time range'}
-							selectedText={''}
-							selectedValues={searchOption.timeRange ? [searchOption.timeRange] : []}
-							options={timeRangeOptions}
-							on:select={e => changeOption(e, 'timeRange')}
-						/>
-						{#if searchOption.timeRange === TimeRange.SpecificDay}
-							<Input
-								type="date"
-								bind:value={searchOption.specificDate}
-								class="mt-2"
-							/>
+					<Col lg="2" class="position-relative">
+						<button
+							type="button"
+							class="form-control text-start d-flex align-items-center justify-content-between"
+							on:click={() => {
+								showDatePicker = !showDatePicker;
+								if (showDatePicker) {
+									datePickerTab = 'relative';
+								}
+							}}
+							style="cursor: pointer;"
+						>
+							<span>{timeRangeDisplayText || 'Select time range'}</span>
+							<i class="bx bx-chevron-down"></i>
+						</button>
+						{#if showDatePicker}
+							<div
+								bind:this={datePickerRef}
+								use:clickoutsideDirective
+								on:clickoutside={(/** @type {any} */ e) => {
+									if (e.detail && e.detail.targetNode && datePickerRef) {
+										if (!datePickerRef.contains(e.detail.targetNode)) {
+											showDatePicker = false;
+										}
+									}
+								}}
+								class="position-absolute top-100 start-0 mt-1 bg-white border rounded shadow-lg"
+								style="z-index: 1050; min-width: 320px; max-width: 350px;"
+							>
+								<ul class="nav nav-tabs border-bottom mb-0 px-2 pt-2" role="tablist">
+									<li class="nav-item flex-fill" role="presentation">
+										<button
+											class="nav-link fw-semibold {datePickerTab === 'relative' ? 'active text-primary' : 'text-muted'}"
+											type="button"
+											role="tab"
+											style="padding: 0.5rem 0.75rem; {datePickerTab === 'relative' ? 'border-bottom: 2px solid var(--bs-primary) !important; margin-bottom: -1px;' : ''}"
+											on:click={() => datePickerTab = 'relative'}
+										>
+											Relative
+										</button>
+									</li>
+									<li class="nav-item flex-fill" role="presentation">
+										<button
+											class="nav-link fw-semibold {datePickerTab === 'custom' ? 'active text-primary' : 'text-muted'}"
+											type="button"
+											role="tab"
+											style="padding: 0.5rem 0.75rem; {datePickerTab === 'custom' ? 'border-bottom: 2px solid var(--bs-primary) !important; margin-bottom: -1px;' : ''}"
+											on:click={() => {
+												datePickerTab = 'custom';
+												// Set default dates to yesterday and today if not already set
+												if (!searchOption.startDate && !searchOption.endDate) {
+													searchOption.startDate = getYesterdayStr();
+													searchOption.endDate = getTodayStr();
+												}
+											}}
+										>
+											Custom
+										</button>
+									</li>
+								</ul>
+								
+								<div class="p-4">
+									{#if datePickerTab === 'relative'}
+										<div class="d-flex flex-column gap-2" style="max-height: 300px; overflow-y: auto;">
+											{#each presetTimeRangeOptions as option}
+												<button
+													type="button"
+													class="btn btn-sm btn-outline-secondary text-start {searchOption.timeRange === option.value ? 'active' : ''}"
+													on:click={(e) => {
+														e.preventDefault();
+														e.stopPropagation();
+														searchOption.timeRange = option.value;
+														searchOption.startDate = '';
+														searchOption.endDate = '';
+														showDatePicker = false;
+														search();
+													}}
+												>
+													{option.label}
+												</button>
+											{/each}
+										</div>
+									{:else if datePickerTab === 'custom'}
+										<div class="mb-3">
+											<label for="start-date-picker-log" class="form-label small mb-2">From:</label>
+											<Input
+												id="start-date-picker-log"
+												type="date"
+												bind:value={searchOption.startDate}
+												class="form-control form-control-sm"
+											/>
+										</div>
+										<div class="mb-4">
+											<label for="end-date-picker-log" class="form-label small mb-2">To:</label>
+											<Input
+												id="end-date-picker-log"
+												type="date"
+												bind:value={searchOption.endDate}
+												class="form-control form-control-sm"
+											/>
+										</div>
+										<div class="d-flex justify-content-end gap-2 mt-3">
+											<Button
+												color="secondary"
+												size="sm"
+												type="button"
+												on:click={(e) => {
+													e.preventDefault();
+													e.stopPropagation();
+													showDatePicker = false;
+												}}
+											>
+												Cancel
+											</Button>
+											<Button
+												color="primary"
+												size="sm"
+												type="button"
+												on:click={(e) => {
+													e.preventDefault();
+													e.stopPropagation();
+													if (searchOption.startDate) {
+														// If endDate is not provided, default to startDate
+														if (!searchOption.endDate) {
+															searchOption.endDate = searchOption.startDate;
+														}
+														// Force reactivity by reassigning the object
+														searchOption = {
+															...searchOption,
+															timeRange: TimeRange.SpecificDay
+														};
+													}
+													showDatePicker = false;
+													search();
+												}}
+											>
+												Confirm
+											</Button>
+										</div>
+									{/if}
+								</div>
+							</div>
 						{/if}
 					</Col>
 					<Col lg="1">

--- a/src/routes/page/instruction/log/+page.svelte
+++ b/src/routes/page/instruction/log/+page.svelte
@@ -374,10 +374,10 @@
 							bind:startDate={searchOption.startDate}
 							bind:endDate={searchOption.endDate}
 							on:change={(e) => {
+								// Only update searchOption, don't trigger query immediately
 								searchOption.timeRange = e.detail.timeRange;
 								searchOption.startDate = e.detail.startDate;
 								searchOption.endDate = e.detail.endDate;
-								search();
 							}}
 						/>
 					</Col>


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Create reusable `TimeRangePicker` component with tabbed interface
  - Supports both relative (preset) and custom date range selection
  - Floating dropdown with tab-based UI for better UX

- Replace `SpecificDay` enum with custom date range support
  - Removes single-day limitation, enables date range selection
  - Uses `startDate` and `endDate` fields instead of `specificDate`

- Defer query execution on time range selection
  - Users must click Filter button to execute queries
  - Prevents immediate API calls during date picker interaction

- Integrate `TimeRangePicker` into conversation and instruction log pages
  - Replaces previous `Select` dropdown with new component
  - Removes conditional date input for specific day selection


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["TimeRangePicker Component"] -->|"Relative Tab"| B["Preset Time Ranges"]
  A -->|"Custom Tab"| C["Date Range Picker"]
  C -->|"startDate + endDate"| D["Custom Date Range"]
  B -->|"Emit Change Event"| E["Update searchOption"]
  D -->|"Emit Change Event"| E
  E -->|"User clicks Filter"| F["Execute Query"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>TimeRangePicker.svelte</strong><dd><code>New TimeRangePicker component with tabbed interface</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/lib/common/shared/TimeRangePicker.svelte

<ul><li>New reusable component for time range selection with tabbed interface<br> <li> Implements relative tab with preset time range options<br> <li> Implements custom tab with date range picker (From/To dates)<br> <li> Emits <code>change</code> event with <code>timeRange</code>, <code>startDate</code>, and <code>endDate</code><br> <li> Uses <code>clickoutsideDirective</code> to close picker when clicking outside</ul>


</details>


  </td>
  <td><a href="https://github.com/SciSharp/BotSharp-UI/pull/423/files#diff-51509f131f310c57bbd5640f5de03c45af8d8832dce3c6b2bbdf33b703097031">+229/-0</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>+page.svelte</strong><dd><code>Replace Select with TimeRangePicker, defer query execution</code></dd></summary>
<hr>

src/routes/page/conversation/+page.svelte

<ul><li>Import and integrate <code>TimeRangePicker</code> component replacing <code>Select</code> <br>dropdown<br> <li> Update <code>searchOption</code> to use <code>startDate</code> and <code>endDate</code> instead of <br><code>specificDate</code><br> <li> Remove <code>getTodayStr()</code> function (moved to component)<br> <li> Remove <code>timeRangeOptions</code> mapping (moved to component)<br> <li> Update <code>convertTimeRange()</code> calls to pass <code>startDate</code> and <code>endDate</code> <br>parameters<br> <li> Remove conditional date input for <code>SpecificDay</code> time range<br> <li> Defer query execution by removing immediate trigger on time range <br>change</ul>


</details>


  </td>
  <td><a href="https://github.com/SciSharp/BotSharp-UI/pull/423/files#diff-72edb425145bdecc0985412a1cf6b28693fd94b85e590906b8f2ed8c4134761a">+16/-35</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>+page.svelte</strong><dd><code>Replace Select with TimeRangePicker, defer query execution</code></dd></summary>
<hr>

src/routes/page/instruction/log/+page.svelte

<ul><li>Import and integrate <code>TimeRangePicker</code> component replacing <code>Select</code> <br>dropdown<br> <li> Update <code>searchOption</code> to use <code>startDate</code> and <code>endDate</code> instead of <br><code>specificDate</code><br> <li> Remove <code>getTodayStr()</code> and <code>timeRangeOptions</code> (moved to component)<br> <li> Update <code>convertTimeRange()</code> calls to pass <code>startDate</code> and <code>endDate</code> <br>parameters<br> <li> Remove conditional date input for <code>SpecificDay</code> time range<br> <li> Defer query execution by removing immediate trigger on time range <br>change</ul>


</details>


  </td>
  <td><a href="https://github.com/SciSharp/BotSharp-UI/pull/423/files#diff-d35914d5bba5bac6164c51593eb0b5664a26f3d83c2de770d6ee409b7122dcf2">+17/-36</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>common.js</strong><dd><code>Update convertTimeRange to support date ranges</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/lib/helpers/utils/common.js

<ul><li>Import <code>CUSTOM_DATE_RANGE</code> constant<br> <li> Update <code>convertTimeRange()</code> function signature to accept <code>startDate</code> and <br><code>endDate</code> instead of <code>specificDate</code><br> <li> Replace <code>TimeRange.SpecificDay</code> case with <code>CUSTOM_DATE_RANGE</code> case<br> <li> Support date range by using <code>endDate</code> (defaults to <code>startDate</code> if not <br>provided)<br> <li> Update JSDoc comments to reflect new parameters</ul>


</details>


  </td>
  <td><a href="https://github.com/SciSharp/BotSharp-UI/pull/423/files#diff-30c43cacf5b3eaf24733983febf9361c12c6b2083e1f64b6cf31f19e61f3c4dc">+9/-7</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>constants.js</strong><dd><code>Add CUSTOM_DATE_RANGE constant, remove SpecificDay</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/lib/helpers/constants.js

<ul><li>Add <code>CUSTOM_DATE_RANGE</code> constant for custom date range identifier<br> <li> Remove <code>SpecificDay</code> option from <code>TIME_RANGE_OPTIONS</code> array<br> <li> Custom date range is now handled separately from preset options</ul>


</details>


  </td>
  <td><a href="https://github.com/SciSharp/BotSharp-UI/pull/423/files#diff-9c5cba4052473b9cefe58d10fb82932f48699ae0ee11d203306365e334f4dc54">+3/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>enums.js</strong><dd><code>Remove SpecificDay from TimeRange enum</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/lib/helpers/enums.js

<ul><li>Remove <code>SpecificDay</code> enum value from <code>TimeRange</code> object<br> <li> Simplifies time range enum to only include preset relative ranges</ul>


</details>


  </td>
  <td><a href="https://github.com/SciSharp/BotSharp-UI/pull/423/files#diff-cd70dcbcf013861ea78c8d511262c95da0cb698ab143291baeb9d891e7ce0c36">+0/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>conversationTypes.js</strong><dd><code>Update ConversationSearchOption type documentation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/lib/helpers/types/conversationTypes.js

<ul><li>Update <code>ConversationSearchOption</code> JSDoc to replace <code>specificDate</code> with <br><code>startDate</code> and <code>endDate</code><br> <li> Document that <code>endDate</code> defaults to <code>startDate</code> if not provided<br> <li> Clarify that custom date range uses <code>CUSTOM_DATE_RANGE</code> identifier</ul>


</details>


  </td>
  <td><a href="https://github.com/SciSharp/BotSharp-UI/pull/423/files#diff-c47f43b4b30c4889f1a796536eff242e4e5d69093a6540077f6572a9ee335890">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

