### PR TITLE
Refine chat box header

### DIFF
--- a/src/lib/styles/pages/_chat.scss
+++ b/src/lib/styles/pages/_chat.scss
@@ -749,6 +749,7 @@
 /* Header bar */
 .cb-head {
     position: relative;
+    z-index: 20;
     font-size: 1rem;
     padding: clamp(0.75rem, 2vmin, 1.25rem) 2%;
     height: 10%;

--- a/src/routes/chat/[agentId]/[conversationId]/chat-box.svelte
+++ b/src/routes/chat/[agentId]/[conversationId]/chat-box.svelte
@@ -1094,6 +1094,8 @@
 	function toggleUserAddStateModal() {
 		isOpenUserAddStateModal = !isOpenUserAddStateModal;
 		if (isOpenUserAddStateModal) {
+			isHeaderStatesOpen = false;
+			isHeaderMenuOpen = false;
 			loadUserAddStates();
 		}
 	}


### PR DESCRIPTION
<h3>PR Summary by Qodo</h3>

Refine chat header layering and close dropdowns when opening Add States
<code>🐞 Bug fix</code> <code>✨ Enhancement</code> <code>🕐 10-20 Minutes</code>

<img src="https://www.qodo.ai/wp-content/uploads/2025/11/light-grey-line.svg" height="10%" alt="Grey Divider">

<h3>Walkthroughs</h3>

<details open>
<summary>Description</summary>

<br/>

<pre>
• Raise chat header stacking order to keep it above overlapping content.
• Close header menus when opening the “Add States” modal to avoid UI conflicts.
</pre>
</details>

<details>
<summary>Diagram</summary>

<br/>

```mermaid
graph TD
  A["chat-box.svelte"] --> B["Header container (.cb-head)"] --> C["Header dropdown menu"] --> D["States submenu"] --> E["Add States modal"]
  F["_chat.scss"] --> B
  E --> C
```

</details>




<details>
<summary>High-Level Assessment</summary>

<br/>

Current approach is appropriate: a targeted z-index tweak fixes header layering, and explicitly closing header menus when the modal opens prevents overlapping UI without introducing new shared state or heavier refactors. Considered extracting a shared “closeHeaderMenus()” helper, but the added indirection isn’t justified for this small change.

</details>

<img src="https://www.qodo.ai/wp-content/uploads/2025/11/light-grey-line.svg" height="10%" alt="Grey Divider">

<h3>File Changes</h3>

<details>
<summary><strong>Bug fix</strong> (2)</summary>

<blockquote>
<details>
<summary><strong>_chat.scss</strong> <code>Raise chat header z-index for correct stacking</code> <code>+1/-0</code></summary>

<br/>

>Raise chat header z-index for correct stacking
>
><pre>
>• Adds a z-index to the chat header (.cb-head) so the header (and its dropdowns) reliably layers above surrounding content/panes.
></pre>
>
><a href='https://github.com/SciSharp/BotSharp-UI/pull/465/files#diff-12b541b8fed04b7bb2da25b04fcf84e941ba8aee3e1f287d75ad28204406cf06'>src/lib/styles/pages/_chat.scss</a>
<hr/>

</details>
</blockquote>

<blockquote>
<details>
<summary><strong>chat-box.svelte</strong> <code>Close header menus when opening Add States modal</code> <code>+2/-0</code></summary>

<br/>

>Close header menus when opening Add States modal
>
><pre>
>• When the user opens the Add States modal, the header dropdown and States submenu are now forced closed to prevent UI overlap and inconsistent open states.
></pre>
>
><a href='https://github.com/SciSharp/BotSharp-UI/pull/465/files#diff-94168668e6f2d07448520397f0d09e112651da024566413b9227c6aad8ba367d'>src/routes/chat/[agentId]/[conversationId]/chat-box.svelte</a>
<hr/>

</details>
</blockquote>

</details>

<img src="https://www.qodo.ai/wp-content/uploads/2025/11/light-grey-line.svg" height="10%" alt="Grey Divider">


<a href="https://www.qodo.ai"><img src="https://www.qodo.ai/wp-content/uploads/2025/03/qodo-logo.svg" width="80" alt="Qodo Logo"></a>